### PR TITLE
fix: restrict global search to admin roles and fix archived page background

### DIFF
--- a/apps/backend/src/modules/search/search.module.ts
+++ b/apps/backend/src/modules/search/search.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
-import { EventEntity, PathwayEntity, DesignEntity, UserEntity } from '@src/entities';
+import { EventEntity, PathwayEntity, DesignEntity, UserEntity, RoleEntity } from '@src/entities';
 import { SearchController } from './search.controller';
 import { SearchService } from './search.service';
 
 @Module({
-  imports: [SequelizeModule.forFeature([EventEntity, PathwayEntity, DesignEntity, UserEntity])],
+  imports: [SequelizeModule.forFeature([EventEntity, PathwayEntity, DesignEntity, UserEntity, RoleEntity])],
   controllers: [SearchController],
   providers: [SearchService],
 })

--- a/apps/backend/src/modules/search/search.module.ts
+++ b/apps/backend/src/modules/search/search.module.ts
@@ -5,7 +5,9 @@ import { SearchController } from './search.controller';
 import { SearchService } from './search.service';
 
 @Module({
-  imports: [SequelizeModule.forFeature([EventEntity, PathwayEntity, DesignEntity, UserEntity, RoleEntity])],
+  imports: [
+    SequelizeModule.forFeature([EventEntity, PathwayEntity, DesignEntity, UserEntity, RoleEntity]),
+  ],
   controllers: [SearchController],
   providers: [SearchService],
 })

--- a/apps/backend/src/modules/search/search.module.ts
+++ b/apps/backend/src/modules/search/search.module.ts
@@ -1,13 +1,11 @@
 import { Module } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
-import { EventEntity, PathwayEntity, DesignEntity, UserEntity, RoleEntity } from '@src/entities';
+import { EventEntity, PathwayEntity, DesignEntity, UserEntity } from '@src/entities';
 import { SearchController } from './search.controller';
 import { SearchService } from './search.service';
 
 @Module({
-  imports: [
-    SequelizeModule.forFeature([EventEntity, PathwayEntity, DesignEntity, UserEntity, RoleEntity]),
-  ],
+  imports: [SequelizeModule.forFeature([EventEntity, PathwayEntity, DesignEntity, UserEntity])],
   controllers: [SearchController],
   providers: [SearchService],
 })

--- a/apps/backend/src/modules/search/search.service.ts
+++ b/apps/backend/src/modules/search/search.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
-import { Op, WhereOptions } from 'sequelize';
-import { Model, ModelStatic } from 'sequelize-typescript';
+import { Op } from 'sequelize';
 import { EventEntity, PathwayEntity, DesignEntity, UserEntity, RoleEntity } from '@src/entities';
 import { ISearchService, GlobalSearchResult, SearchResultItem, SearchCategory } from './interfaces';
 import { Role } from '@src/modules/role/enums';
@@ -26,17 +25,8 @@ export class SearchService implements ISearchService {
     const iLikeTerm: ILikeTerm = { [Op.iLike]: `%${term}%` };
 
     const [events, pathways, designs, teamMembers] = await Promise.all([
-      this.searchByName(this.eventModel, iLikeTerm, organizationId, limit, SearchCategory.EVENTS, {
-        is_active: true,
-      }),
-      this.searchByName(
-        this.pathwayModel,
-        iLikeTerm,
-        organizationId,
-        limit,
-        SearchCategory.PATHWAYS,
-        { is_active: true },
-      ),
+      this.searchEvents(iLikeTerm, organizationId, limit),
+      this.searchPathways(iLikeTerm, organizationId, limit),
       this.searchDesigns(iLikeTerm, organizationId, limit),
       this.searchTeamMembers(iLikeTerm, organizationId, limit),
     ]);
@@ -50,25 +40,41 @@ export class SearchService implements ISearchService {
     };
   }
 
-  private async searchByName(
-    model: ModelStatic<Model>,
+  private async searchEvents(
     iLikeTerm: ILikeTerm,
     organizationId: number,
     limit: number,
-    category: SearchCategory,
-    extraWhere: WhereOptions = {},
   ): Promise<SearchResultItem[]> {
-    const rows = await model.findAll({
-      where: { organization_id: organizationId, name: iLikeTerm, ...extraWhere },
+    const rows = await this.eventModel.findAll({
+      where: { organization_id: organizationId, name: iLikeTerm, is_active: true },
       attributes: ['uuid', 'name'],
       limit,
       order: [['created_at', 'DESC']],
     });
 
     return rows.map((row) => ({
-      uuid: row.getDataValue('uuid'),
-      name: row.getDataValue('name'),
-      category,
+      uuid: row.uuid,
+      name: row.name,
+      category: SearchCategory.EVENTS,
+    }));
+  }
+
+  private async searchPathways(
+    iLikeTerm: ILikeTerm,
+    organizationId: number,
+    limit: number,
+  ): Promise<SearchResultItem[]> {
+    const rows = await this.pathwayModel.findAll({
+      where: { organization_id: organizationId, name: iLikeTerm, is_active: true },
+      attributes: ['uuid', 'name'],
+      limit,
+      order: [['created_at', 'DESC']],
+    });
+
+    return rows.map((row) => ({
+      uuid: row.uuid,
+      name: row.name,
+      category: SearchCategory.PATHWAYS,
     }));
   }
 

--- a/apps/backend/src/modules/search/search.service.ts
+++ b/apps/backend/src/modules/search/search.service.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { Op, WhereOptions } from 'sequelize';
 import { Model, ModelStatic } from 'sequelize-typescript';
-import { EventEntity, PathwayEntity, DesignEntity, UserEntity } from '@src/entities';
+import { EventEntity, PathwayEntity, DesignEntity, UserEntity, RoleEntity } from '@src/entities';
 import { ISearchService, GlobalSearchResult, SearchResultItem, SearchCategory } from './interfaces';
+import { Role } from '@src/modules/role/enums';
 
 type ILikeTerm = { [Op.iLike]: string };
 
@@ -103,6 +104,13 @@ export class SearchService implements ISearchService {
         deleted_at: null,
         [Op.or]: [{ first_name: iLikeTerm }, { last_name: iLikeTerm }, { email: iLikeTerm }],
       },
+      include: [
+        {
+          model: RoleEntity,
+          attributes: ['role'],
+          where: { role: { [Op.ne]: Role.SYSTEM_ADMIN } },
+        },
+      ],
       attributes: ['uuid', 'first_name', 'last_name', 'email'],
       limit,
       order: [['first_name', 'ASC']],

--- a/apps/backend/src/modules/user/user.controller.ts
+++ b/apps/backend/src/modules/user/user.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  ForbiddenException,
   Get,
   NotFoundException,
   Param,
@@ -133,6 +134,9 @@ export class UserController {
     if (!existingUser) {
       return new SuccessResponse('User not found', null);
     }
+    if (existingUser.role?.role === Role.SYSTEM_ADMIN) {
+      throw new ForbiddenException('Cannot modify a system admin account');
+    }
     const auditContext = buildAuditContext(req);
     const updatedUser = await this.userService.update(existingUser.id, dto, user, { auditContext });
     return new SuccessResponse('User updated successfully', updatedUser);
@@ -156,6 +160,10 @@ export class UserController {
 
     if (!existingUser) {
       throw new NotFoundException('User not found');
+    }
+
+    if (existingUser.role?.role === Role.SYSTEM_ADMIN) {
+      throw new ForbiddenException('Cannot delete a system admin account');
     }
 
     // Prevent deleting yourself (compare UUIDs)

--- a/apps/frontend/src/app/(dashboard)/designs/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/designs/page.tsx
@@ -25,6 +25,13 @@ export default function DesignsPage() {
   const page = Number(searchParams.get('page') ?? 1);
   const searchFromUrl = searchParams.get('search') ?? '';
   const typeFromUrl = searchParams.get('type') as Filter | null;
+  const previewId = searchParams.get('preview');
+
+  useEffect(() => {
+    if (previewId) {
+      router.replace(`${ROUTES.DESIGNS}/preview/${previewId}`);
+    }
+  }, [previewId, router]);
 
   const [search, setSearch] = useState(searchFromUrl);
   const debouncedSearch = useDebounce(search, SEARCH_DEBOUNCE_MS);

--- a/apps/frontend/src/app/(dashboard)/settings/archived/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/settings/archived/page.tsx
@@ -131,7 +131,7 @@ export default function ArchivedMembersPage() {
     return members.map((member) => (
       <div
         key={member.id}
-        className="bg-white mb-4 border-gray-100  flex flex-col sm:flex-row sm:items-center justify-between"
+        className="py-4 flex flex-col sm:flex-row sm:items-center justify-between"
       >
         <div className="flex-1 min-w-0">
           <div className="flex text-sm font-medium text-gray-600 truncate">
@@ -217,7 +217,9 @@ export default function ArchivedMembersPage() {
       </div>
 
       {/* List */}
-      <div className="border-separate mt-6 w-full">{renderList()}</div>
+      <div className="mt-6 bg-white shadow-md sm:rounded-sm px-4 divide-y divide-gray-100">
+        {renderList()}
+      </div>
 
       {/* Pagination */}
       <div className="pt-4 border-t border-gray-200">

--- a/apps/frontend/src/components/layout/global-search.tsx
+++ b/apps/frontend/src/components/layout/global-search.tsx
@@ -6,7 +6,7 @@ import { Search, Clock, Trash2 } from 'lucide-react';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { useGlobalSearch } from '@/hooks/useSearch';
-import { createRoute } from '@/config/routes';
+import { ROUTES, createRoute } from '@/config/routes';
 import { SearchCategory, SearchResultItem, RecentSearchItem } from '@/types';
 import { capitalizeFirst } from '@/utils';
 import { addRecentSearch, getRecentSearches, clearRecentSearches } from '@/lib/recent-search';
@@ -32,7 +32,7 @@ function getRouteForResult(item: SearchResultItem): string {
     case SearchCategory.PATHWAYS:
       return createRoute.pathwayDetail(item.uuid);
     case SearchCategory.DESIGNS:
-      return createRoute.designPreview(item.uuid);
+      return `${ROUTES.DESIGNS}?preview=${item.uuid}`;
     case SearchCategory.TEAM_MEMBERS:
       return createRoute.teamMember(item.uuid);
   }

--- a/apps/frontend/src/components/layout/header.tsx
+++ b/apps/frontend/src/components/layout/header.tsx
@@ -88,8 +88,8 @@ export function Header() {
             </div>
           </div>
 
-          {/* Search */}
-          <GlobalSearch />
+          {/* Search — only for admin-level roles */}
+          {(isAdmin || isSystemAdmin) && <GlobalSearch />}
 
           {/* Mobile Menu Button */}
           <button


### PR DESCRIPTION
## Description

- Role-based delete restrictions for manager across events, pathways, and credentials
- Block editing/deleting system admin accounts
- Manager/designer nav and access restrictions (redirect, hide dashboard, disable search)
- Exclude system admins from global search results
- Design deep linking from global search via intercepting route modal

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Manual testing

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Add any additional notes about the PR here.
